### PR TITLE
Fix issue #1: BOX CLIのダミーコマンド追加

### DIFF
--- a/mocks/box
+++ b/mocks/box
@@ -3,8 +3,16 @@
 if [[ "$1" == "folders:upload" ]]; then
   echo "[MOCK] box $@"
   exit "${MOCK_BOX_RTESULT:-0}"
+elif [[ "$1" == "configure:environments:add" ]]; then
+  echo "[MOCK] box $@"
+  exit "${MOCK_BOX_CONFIGURE_ENVIRONMENTS_ADD_RESULT:-0}"
+elif [[ "$1" == "configure:environments:delete" ]]; then
+  echo "[MOCK] box $@"
+  exit "${MOCK_BOX_CONFIGURE_ENVIRONMENTS_DELETE_RESULT:-0}"
+elif [[ "$1" == "folders:items" ]]; then
+  echo "folder,999,0,0,${MOCK_BOX_ITEM_PATH},,,,"
+  exit "${MOCK_BOX_FOLDERS_ITEMS_RESULT:-0}"
 else
-    echo "box CLI not found" >&2
-    exit 127
-  fi
+  echo "box CLI not found" >&2
+  exit 127
 fi

--- a/tests/out.txt
+++ b/tests/out.txt
@@ -1,0 +1,1 @@
+box CLI not found

--- a/tests/test_box_mock.sh
+++ b/tests/test_box_mock.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+MOCKS=../mocks/box
+
+# Test configure:environments:add
+echo "Test: configure:environments:add"
+MOCK_BOX_CONFIGURE_ENVIRONMENTS_ADD_RESULT=5 $MOCKS configure:environments:add foo bar > out.txt 2>&1 || code=$?
+grep '\[MOCK\] box configure:environments:add foo bar' out.txt
+[ "$code" = "5" ]
+
+# Test configure:environments:delete
+echo "Test: configure:environments:delete"
+MOCK_BOX_CONFIGURE_ENVIRONMENTS_DELETE_RESULT=6 $MOCKS configure:environments:delete baz > out.txt 2>&1 || code=$?
+grep '\[MOCK\] box configure:environments:delete baz' out.txt
+[ "$code" = "6" ]
+
+# Test folders:items
+echo "Test: folders:items"
+MOCK_BOX_ITEM_PATH=/tmp/testpath MOCK_BOX_FOLDERS_ITEMS_RESULT=7 $MOCKS folders:items arg1 arg2 > out.txt 2>&1 || code=$?
+grep 'folder,999,0,0,/tmp/testpath' out.txt
+[ "$code" = "7" ]
+
+# Test unknown command
+echo "Test: unknown command"
+! $MOCKS unknowncmd > out.txt 2>&1
+grep 'box CLI not found' out.txt
+


### PR DESCRIPTION
This pull request fixes #1.

The changes made to the mocks/box script address all points in the issue description:

1. For the commands box configure:environments:add and box configure:environments:delete, the script now echoes the command and its arguments (via echo "[MOCK] box $@") and exits with a code determined by the respective environment variables (MOCK_BOX_CONFIGURE_ENVIRONMENTS_ADD_RESULT and MOCK_BOX_CONFIGURE_ENVIRONMENTS_DELETE_RESULT). This matches the requirement to display the arguments and customize the return code per command.

2. For box folders:items, the script now echoes the required output format (folder,999,0,0,${MOCK_BOX_ITEM_PATH},,,,) and exits with a code set by MOCK_BOX_FOLDERS_ITEMS_RESULT, as requested.

3. The script uses command-specific environment variables for return codes, as specified.

4. The new test script (tests/test_box_mock.sh) verifies that each command produces the expected output and exit code, and that unknown commands return the correct error message.

Therefore, the changes directly implement the requested behavior and provide tests to confirm it, resolving the issue as described.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌